### PR TITLE
Support multiple Route annotations on a single Controller method

### DIFF
--- a/src/Orlex/AnnotationManager/Compiler/AbstractCompiler.php
+++ b/src/Orlex/AnnotationManager/Compiler/AbstractCompiler.php
@@ -1,12 +1,12 @@
 <?php
 namespace Orlex\AnnotationManager\Compiler;
 
-use Doctrine\Common\Annotations\IndexedReader;
+use Doctrine\Common\Annotations\Reader;
 use Orlex\AnnotationManager\Loader\FileLoader;
 
 abstract class AbstractCompiler {
     /**
-     * @var \Doctrine\Common\Annotations\IndexedReader
+     * @var \Doctrine\Common\Annotations\Reader
      */
     protected $reader;
 
@@ -16,10 +16,10 @@ abstract class AbstractCompiler {
     protected $loader;
 
     /**
-     * @param IndexedReader $reader
+     * @param Reader $reader
      * @param FileLoader $loader
      */
-    public function __construct(IndexedReader $reader, FileLoader $loader) {
+    public function __construct(Reader $reader, FileLoader $loader) {
         $this->reader = $reader;
         $this->loader = $loader;
     }
@@ -65,14 +65,14 @@ abstract class AbstractCompiler {
     }
 
     /**
-     * @param IndexedReader $reader
+     * @param Reader $reader
      */
-    public function setReader(IndexedReader $reader) {
+    public function setReader(Reader $reader) {
         $this->reader = $reader;
     }
 
     /**
-     * @return IndexedReader
+     * @return Reader
      */
     public function getReader() {
         return $this->reader;

--- a/src/Orlex/AnnotationManager/Compiler/Route.php
+++ b/src/Orlex/AnnotationManager/Compiler/Route.php
@@ -37,6 +37,8 @@ class Route extends AbstractCompiler {
             return is_object($annotation) && $annotation instanceof RouteAnnotation;
         });
 
+        if (count($routes) > 1) trigger_error('Multiple Route annotations at a class level are not supported', E_USER_ERROR);
+
         if ($routes) {
             /** @var $route \Orlex\Annotation\Route */
             $route = $routes[0];

--- a/src/Orlex/ServiceProvider.php
+++ b/src/Orlex/ServiceProvider.php
@@ -27,13 +27,13 @@ class ServiceProvider implements ServiceProviderInterface {
         ////
         // Internal Services
         ////
-        $app['orlex.annotation.indexedreader'] = $app->share(function($app) {
+        $app['orlex.annotation.reader'] = $app->share(function($app) {
             AnnotationRegistry::registerAutoloadNamespace('Orlex\Annotation', dirname(__DIR__));
             foreach ($app['orlex.annotation.dirs'] as $dir => $namespace) {
                 AnnotationRegistry::registerAutoloadNamespace($namespace, $dir);
             }
 
-            return new Annotations\IndexedReader(new Annotations\AnnotationReader());
+            return new Annotations\AnnotationReader();
         });
 
         $app['orlex.directoryloader'] = $app->share(function() {
@@ -41,7 +41,7 @@ class ServiceProvider implements ServiceProviderInterface {
         });
 
         $app['orlex.route.compiler'] = $app->share(function($app) {
-            $compiler = new Compiler\Route($app['orlex.annotation.indexedreader'], $app['orlex.directoryloader']);
+            $compiler = new Compiler\Route($app['orlex.annotation.reader'], $app['orlex.directoryloader']);
             $compiler->setContainer($app);
             return $compiler;
         });

--- a/tests/Orlex/AnnotationManager/Compiler/AbstractCompilerTest.php
+++ b/tests/Orlex/AnnotationManager/Compiler/AbstractCompilerTest.php
@@ -18,7 +18,7 @@ class AbstractCompilerTest extends \PHPUnit_Framework_TestCase {
     protected $delegate;
 
     public function setUp() {
-        $this->mock = new MockAbstractCompiler(new Annotations\IndexedReader(new Annotations\AnnotationReader()), new FileLoader());
+        $this->mock = new MockAbstractCompiler(new Annotations\AnnotationReader(), new FileLoader());
         $this->delegate = m::mock(); //->shouldIgnoreMissing();
 
         $this->mock->delegate = $this->delegate;
@@ -42,7 +42,7 @@ class AbstractCompilerTest extends \PHPUnit_Framework_TestCase {
                            ->with($reflClassMatcher, m::on(function($inp) use ($reflMethod){ return $inp->getName() == $reflMethod->getName(); }), $expectedAnnotations);
         }
 
-        $reader = m::mock('Doctrine\Common\Annotations\IndexedReader');
+        $reader = m::mock('Doctrine\Common\Annotations\Reader');
         $reader->shouldReceive('getClassAnnotations')
                ->once()
                ->withAnyArgs()
@@ -62,7 +62,7 @@ class AbstractCompilerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testGetAndSetReader() {
-        $this->mock->setReader($reader = m::mock('Doctrine\Common\Annotations\IndexedReader'));
+        $this->mock->setReader($reader = m::mock('Doctrine\Common\Annotations\Reader'));
         $this->assertEquals($reader, $this->mock->getReader());
     }
 

--- a/tests/Orlex/ServiceProviderTest.php
+++ b/tests/Orlex/ServiceProviderTest.php
@@ -43,7 +43,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('Silex\ServiceControllerResolver', $this->app['resolver'], 'Registers the ServiceControllerServiceProvider');
         $this->assertEquals([], $this->app['orlex.controller.dirs'], 'Registers empty directory placeholder');
         $this->assertEquals([], $this->app['orlex.annotation.dirs'], 'Registers empty annotation placeholder');
-        $this->assertTrue(isset($this->app['orlex.annotation.indexedreader']), 'Registers indexed reader');
+        $this->assertTrue(isset($this->app['orlex.annotation.reader']), 'Registers annotation reader');
         $this->assertTrue(isset($this->app['orlex.directoryloader']), 'Registers directory loader');
         $this->assertTrue(isset($this->app['orlex.route.compiler']), 'Registers route compiler');
 
@@ -54,9 +54,9 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
         ];
 
         //Check indexed reader
-        /** @var $reader \Doctrine\Common\Annotations\IndexedReader */
-        $reader = $this->app['orlex.annotation.indexedreader'];
-        $this->assertInstanceOf('Doctrine\Common\Annotations\IndexedReader', $reader);
+        /** @var $reader \Doctrine\Common\Annotations\Reader */
+        $reader = $this->app['orlex.annotation.reader'];
+        $this->assertInstanceOf('Doctrine\Common\Annotations\Reader', $reader);
 
         //Check directory loader
         /** @var $loader \Orlex\AnnotationManager\Loader\DirectoryLoader */
@@ -67,7 +67,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase {
         /** @var $compiler \Orlex\AnnotationManager\Compiler\Route */
         $compiler = $this->app['orlex.route.compiler'];
         $this->assertInstanceOf('Orlex\AnnotationManager\Compiler\Route', $compiler);
-        $this->assertEquals($reader, $compiler->getReader(), 'Reader is set from orlex.annotation.indexedreader');
+        $this->assertEquals($reader, $compiler->getReader(), 'Reader is set from orlex.annotation.reader');
         $this->assertEquals($loader, $compiler->getLoader(), 'Loader is set from orlex.directoryloader');
 
 


### PR DESCRIPTION
A side-effect of this is Controller classes can also use multiple Route annotations. If so, only the first annotation will be used.
